### PR TITLE
Fix for race in acquire with test case

### DIFF
--- a/cachelib/CMakeLists.txt
+++ b/cachelib/CMakeLists.txt
@@ -396,4 +396,10 @@ if (BUILD_TESTS)
     RENAME
       Makefile
   )
+  install(
+    FILES
+      ${CACHELIB_HOME}/allocator/tests/ChainedItemParentAcquireAfterMove.gdb
+    DESTINATION
+      ${TESTS_INSTALL_DIR}
+  )
 endif()

--- a/cachelib/allocator/CacheItem-inl.h
+++ b/cachelib/allocator/CacheItem-inl.h
@@ -248,6 +248,11 @@ RefcountWithFlags::Value CacheItem<CacheTrait>::unmarkMoving() noexcept {
 }
 
 template <typename CacheTrait>
+RefcountWithFlags::Value CacheItem<CacheTrait>::unmarkMovingAndIncRef() noexcept {
+  return ref_.unmarkMovingAndIncRef();
+}
+
+template <typename CacheTrait>
 bool CacheItem<CacheTrait>::isMoving() const noexcept {
   return ref_.isMoving();
 }

--- a/cachelib/allocator/CacheItem.h
+++ b/cachelib/allocator/CacheItem.h
@@ -380,6 +380,7 @@ class CACHELIB_PACKED_ATTR CacheItem {
    */
   bool markMoving();
   RefcountWithFlags::Value unmarkMoving() noexcept;
+  RefcountWithFlags::Value unmarkMovingAndIncRef() noexcept;
   bool isMoving() const noexcept;
   bool isOnlyMoving() const noexcept;
 

--- a/cachelib/allocator/tests/AllocatorTypeTest.cpp
+++ b/cachelib/allocator/tests/AllocatorTypeTest.cpp
@@ -292,6 +292,10 @@ TYPED_TEST(BaseAllocatorTest, TransferChainAfterMoving) {
   this->testTransferChainAfterMoving();
 }
 
+TYPED_TEST(BaseAllocatorTest, ChainedItemParentAcquireAfterMove) {
+  this->testChainedItemParentAcquireAfterMove();
+}
+
 TYPED_TEST(BaseAllocatorTest, AddAndPopChainedItemMultithread) {
   this->testAddAndPopChainedItemMultithread();
 }

--- a/cachelib/allocator/tests/ChainedItemParentAcquireAfterMove.gdb
+++ b/cachelib/allocator/tests/ChainedItemParentAcquireAfterMove.gdb
@@ -1,0 +1,22 @@
+break gdb_sync1
+c
+set scheduler-locking on
+break acquire
+c
+c
+c
+c
+thread 1
+set scheduler-locking on
+del 2
+break gdb_sync2
+c
+thread 4
+set scheduler-locking on
+break gdb_sync3
+c
+thread 1
+set scheduler-locking off
+break gdb_sync4
+c
+c


### PR DESCRIPTION
The test uses gdb to pause threads so that we can interleave an eviction and the corresponding acquire() call from the mover thread.